### PR TITLE
Fix "Theme parsing error" GTK warnings

### DIFF
--- a/themes/Kanagawa-B-LB/gtk-3.0/gtk-dark.css
+++ b/themes/Kanagawa-B-LB/gtk-3.0/gtk-dark.css
@@ -6625,14 +6625,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-B-LB/gtk-3.0/gtk.css
+++ b/themes/Kanagawa-B-LB/gtk-3.0/gtk.css
@@ -6625,14 +6625,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-B/gtk-3.0/gtk-dark.css
+++ b/themes/Kanagawa-B/gtk-3.0/gtk-dark.css
@@ -6700,14 +6700,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-B/gtk-3.0/gtk.css
+++ b/themes/Kanagawa-B/gtk-3.0/gtk.css
@@ -6700,14 +6700,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-BL-LB/gtk-3.0/gtk-dark.css
+++ b/themes/Kanagawa-BL-LB/gtk-3.0/gtk-dark.css
@@ -6613,14 +6613,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-BL-LB/gtk-3.0/gtk.css
+++ b/themes/Kanagawa-BL-LB/gtk-3.0/gtk.css
@@ -6613,14 +6613,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-BL/gtk-3.0/gtk-dark.css
+++ b/themes/Kanagawa-BL/gtk-3.0/gtk-dark.css
@@ -6688,14 +6688,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }

--- a/themes/Kanagawa-BL/gtk-3.0/gtk.css
+++ b/themes/Kanagawa-BL/gtk-3.0/gtk.css
@@ -6688,14 +6688,14 @@ popover.emoji-completion .emoji:hover {
 
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):last-child:dir(
-    ltr
-  ):disabled,
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):last-child:dir(ltr):disabled,
 .path-bar-box
   .linked.nautilus-path-bar
-  button:not(.suggested-action):not(.destructive-action):first-child:dir(
-    rtl
-  ):disabled {
+  button:not(.suggested-action):not(
+    .destructive-action
+  ):first-child:dir(rtl):disabled {
   color: #e6c384;
   background-color: #2a2a37;
 }


### PR DESCRIPTION
### Problem

When I set the theme to `Kanagawa-Borderless` (`Kanagawa-B/gtk-3.0/gtk.css`), launching applications will generate the warning message:
```sh
(<app>:__): Gtk-WARNING **: 10:54:10.905: Theme parsing error: gtk.css:6691:68: Invalid name of pseudo-class
```

### Root cause

Breaking lines at `:dir()` doesn't seem to be allowed and leads to "Invalid name of pseudo-class" parsing errors.

```css
.path-bar-box
  .linked.nautilus-path-bar
  button:not(.suggested-action):not(.destructive-action):last-child:dir(
    ltr
  ):disabled
```

### Fix

I changed all occurrences of this kind of line break to the following and no warning message is generated.

```css
.path-bar-box
  .linked.nautilus-path-bar
  button:not(.suggested-action):not(
    .destructive-action
  ):last-child:dir(ltr):disabled
```